### PR TITLE
Add live summary and deal history pages with grouping filters

### DIFF
--- a/src/app/common/data/menu.ts
+++ b/src/app/common/data/menu.ts
@@ -5,8 +5,12 @@ export const verticalMenuItems = [
     new Menu (214, 'Live Deals', '/deals-live', null, 'sync_alt', null, false, 0),
     new Menu (215, 'Live Orders', '/live-orders', null, 'list_alt', null, false, 0),
     new Menu (216, 'Jobbing Deals', '/jobbing-deals', null, 'history', null, false, 0),
+    new Menu (220, 'Standing', '/standing', null, 'bar_chart', null, false, 0),
+    new Menu (221, 'Live Summary', '/live-summary', null, 'table_chart', null, false, 0),
     new Menu (217, 'Manager Master', '/manager-master', null, 'supervisor_account', null, false, 0),
-    new Menu (218, 'Broker Master', '/broker-master', null, 'people', null, false, 0)
+    new Menu (218, 'Broker Master', '/broker-master', null, 'people', null, false, 0),
+    new Menu (219, 'Client Master', '/client-master', null, 'person', null, false, 0),
+    new Menu (222, 'Deal History', '/deal-history', null, 'history', null, false, 0)
 ]
 
 export const horizontalMenuItems = [
@@ -14,6 +18,10 @@ export const horizontalMenuItems = [
     new Menu (214, 'Live Deals', '/deals-live', null, 'sync_alt', null, false, 0),
     new Menu (215, 'Live Orders', '/live-orders', null, 'list_alt', null, false, 0),
     new Menu (216, 'Jobbing Deals', '/jobbing-deals', null, 'history', null, false, 0),
+    new Menu (220, 'Standing', '/standing', null, 'bar_chart', null, false, 0),
+    new Menu (221, 'Live Summary', '/live-summary', null, 'table_chart', null, false, 0),
     new Menu (217, 'Manager Master', '/manager-master', null, 'supervisor_account', null, false, 0),
-    new Menu (218, 'Broker Master', '/broker-master', null, 'people', null, false, 0)
+    new Menu (218, 'Broker Master', '/broker-master', null, 'people', null, false, 0),
+    new Menu (219, 'Client Master', '/client-master', null, 'person', null, false, 0),
+    new Menu (222, 'Deal History', '/deal-history', null, 'history', null, false, 0)
 ]

--- a/src/app/pages/client-master/client-master.component.html
+++ b/src/app/pages/client-master/client-master.component.html
@@ -1,0 +1,55 @@
+<mat-toolbar class="toolbar">
+  <div class="left">
+    <mat-form-field appearance="outline">
+      <mat-label>Login</mat-label>
+      <mat-select
+        [(ngModel)]="selectedLogin"
+        (openedChange)="onLoginDropdownOpen($event)"
+      >
+        <mat-option class="search-option" disabled>
+          <mat-form-field
+            appearance="outline"
+            class="login-search-field"
+            (click)="$event.stopPropagation()"
+          >
+            <mat-icon matPrefix>search</mat-icon>
+            <input
+              matInput
+              #loginSearch
+              placeholder="Search logins"
+              autocomplete="off"
+              [ngModel]="loginFilter"
+              (ngModelChange)="filterLogins($event)"
+              (click)="$event.stopPropagation()"
+              (keydown)="$event.stopPropagation()"
+              (keyup)="$event.stopPropagation()"
+            />
+          </mat-form-field>
+        </mat-option>
+        <mat-option [value]="null">-- Clear Selection --</mat-option>
+        <mat-option *ngFor="let l of filteredLogins" [value]="l.login">
+          {{ l.login }} - {{ l.name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-checkbox [(ngModel)]="showUpdated">Show Updated Logins</mat-checkbox>
+    <button mat-flat-button color="accent" (click)="show()">Show</button>
+  </div>
+  <div class="right">
+    <mat-form-field appearance="outline">
+      <mat-label>Search</mat-label>
+      <input matInput (input)="onFilterTextBoxChanged($event)" />
+    </mat-form-field>
+    <button mat-icon-button title="Export CSV" (click)="exportCsv()">
+      <mat-icon>table_view</mat-icon>
+    </button>
+  </div>
+</mat-toolbar>
+<div class="grid-wrapper">
+  <ag-grid-angular
+    class="ag-theme-alpine full-grid"
+    [gridOptions]="gridOptions"
+    (gridReady)="onGridReady($event)"
+    (cellClicked)="onCellClicked($event)"
+  ></ag-grid-angular>
+</div>

--- a/src/app/pages/client-master/client-master.component.scss
+++ b/src/app/pages/client-master/client-master.component.scss
@@ -1,0 +1,64 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.grid-wrapper {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
+.full-grid {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+}
+
+
+mat-toolbar.toolbar {
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  mat-form-field {
+    width: 300px;
+  }
+}
+
+:host ::ng-deep .search-option {
+  padding: 4px 8px;
+  cursor: default;
+}
+
+:host ::ng-deep .search-option.mat-mdc-option.mdc-list-item--disabled {
+  color: inherit;
+}
+
+:host ::ng-deep .login-search-field {
+  width: 100%;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  mat-form-field {
+    width: 250px;
+  }
+}
+
+:host ::ng-deep .action-icon {
+  cursor: pointer;
+  margin-right: 4px;
+}
+
+:host ::ng-deep .ag-row {
+  height: 32px;
+}

--- a/src/app/pages/client-master/client-master.component.ts
+++ b/src/app/pages/client-master/client-master.component.ts
@@ -1,0 +1,388 @@
+import { Component, OnInit, ViewChild, ElementRef, HostListener } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { AgGridModule } from 'ag-grid-angular';
+import {
+  GridApi,
+  GridOptions,
+  GridReadyEvent,
+  CellClickedEvent,
+  ModuleRegistry,
+  AllCommunityModule,
+  ICellRendererParams,
+} from 'ag-grid-community';
+import { MasterService, MasterItem } from '@services/master.service';
+import {
+  ClientMasterRequest,
+  LoginClientInfo,
+  LoginOption,
+} from '@services/master.models';
+import { format } from 'date-fns';
+import { Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+@Component({
+  selector: 'app-client-master',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatCheckboxModule,
+    MatButtonModule,
+    MatIconModule,
+    MatInputModule,
+    MatToolbarModule,
+    MatDialogModule,
+    AgGridModule
+  ],
+  templateUrl: './client-master.component.html',
+  styleUrls: ['./client-master.component.scss']
+})
+export class ClientMasterComponent implements OnInit {
+  logins: LoginOption[] = [];
+  filteredLogins: LoginOption[] = [];
+  selectedLogin: number | null = null;
+  showUpdated = false;
+  loginFilter = '';
+  currencies: MasterItem[] = [];
+  @ViewChild('loginSearch') loginSearch!: ElementRef<HTMLInputElement>;
+  gridOptions: GridOptions<LoginClientInfo> = {
+    theme: 'legacy',
+    rowHeight: 25,
+    columnDefs: [
+      {
+        headerName: 'Actions',
+        cellRenderer: (params: ICellRendererParams) =>
+          '<span class="material-icons action-icon edit">edit</span>' +
+          '<span class="material-icons action-icon delete">delete</span>',
+        width: 100,
+        minWidth: 100
+      },
+      { field: 'login', headerName: 'Login', flex: 1 },
+      { field: 'userName', headerName: 'User Name', flex: 1 },
+      { field: 'managerName', headerName: 'Manager', flex: 1 },
+      { field: 'brokerName', headerName: 'Broker', flex: 1 },
+      { field: 'exchange', headerName: 'Exchange', flex: 1 },
+      {
+        field: 'brokShare',
+        headerName: 'Brok Share',
+        type: 'numericColumn',
+        valueFormatter: params => this.formatNumber(params.value),
+        cellStyle: { textAlign: 'right' }
+      },
+      {
+        field: 'managerShare',
+        headerName: 'Manager Share',
+        type: 'numericColumn',
+        valueFormatter: params => this.formatNumber(params.value),
+        cellStyle: { textAlign: 'right' }
+      },
+      { field: 'currency', headerName: 'Currency', flex: 1 },
+      {
+        field: 'commission',
+        headerName: 'Commission',
+        type: 'numericColumn',
+        valueFormatter: params => this.formatNumber(params.value),
+        cellStyle: { textAlign: 'right' }
+      },
+      {
+        field: 'createdDate',
+        headerName: 'Created Date',
+        flex: 1,
+        valueFormatter: params =>
+          params.value ? format(new Date(params.value), 'dd/MM/yyyy HH:mm:ss') : ''
+      }
+    ],
+    defaultColDef: {
+      resizable: true,
+      sortable: true,
+      filter: true,
+      minWidth: 80,
+    },
+    rowData: [] as LoginClientInfo[]
+  };
+
+  private gridApi!: GridApi<LoginClientInfo>;
+
+  constructor(private svc: MasterService, private dialog: MatDialog) {}
+
+  ngOnInit(): void {
+    this.svc.getLogins().subscribe(res => {
+      this.logins = res;
+      this.filteredLogins = res;
+    });
+    this.svc.getCurrencies().subscribe(res => (this.currencies = res));
+  }
+
+  onGridReady(event: GridReadyEvent<LoginClientInfo>) {
+    this.gridApi = event.api;
+    this.gridApi.sizeColumnsToFit();
+  }
+
+  show() {
+    this.svc
+      .getLoginsWithClientInfo(this.selectedLogin, this.showUpdated)
+      .subscribe(res => {
+        this.gridApi.setGridOption('rowData', res);
+        this.gridApi.sizeColumnsToFit();
+      });
+  }
+
+  onCellClicked(event: CellClickedEvent<LoginClientInfo>) {
+    if (event.colDef.headerName !== 'Actions' || !event.data) {
+      return;
+    }
+    const target = event.event?.target as HTMLElement | null;
+    if (!target) return;
+    if (target.classList.contains('edit')) {
+      const {
+        clientId,
+        login,
+        managerId,
+        brokerId,
+        exId,
+        brokShare,
+        managerShare,
+        currency,
+        commission,
+      } = event.data;
+      const action = clientId ? 'UPDATE' as const : 'ADD' as const;
+      const currencyId = this.currencies.find(
+        c => c.name === currency || c.code === currency
+      )?.id ?? 0;
+      this.openDialog({
+        action,
+        id: clientId ?? 0,
+        login,
+        managerId: managerId ?? 0,
+        brokerId: brokerId ?? 0,
+        exIds: exId != null ? [exId] : [],
+        brokShare: brokShare ?? 0,
+        managerShare: managerShare ?? 0,
+        currencyId,
+        commission: commission ?? 0,
+        reverseStanding: ''
+      });
+    }
+    if (target.classList.contains('delete')) {
+      const id = event.data.clientId;
+      if (id) {
+        this.delete(id);
+      }
+    }
+  }
+
+  openDialog(data: ClientMasterRequest) {
+    const ref = this.dialog.open(ClientMasterDialogComponent, {
+      data: { ...data }
+    });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.svc.saveClientMaster(result).subscribe(() => this.show());
+      }
+    });
+  }
+
+  delete(id: number) {
+    if (!id) return;
+    if (confirm('Are you sure you want to delete this client?')) {
+      this.svc.deleteClientMaster(id).subscribe(() => this.show());
+    }
+  }
+
+  onFilterTextBoxChanged(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.gridApi.setGridOption('quickFilterText', value);
+  }
+
+  onLoginDropdownOpen(open: boolean) {
+    if (open) {
+      this.loginFilter = '';
+      this.filteredLogins = this.logins.slice();
+      setTimeout(() => this.loginSearch?.nativeElement.focus());
+    }
+  }
+
+  filterLogins(value: string) {
+    this.loginFilter = value;
+    const term = value.toLowerCase();
+    this.filteredLogins = this.logins.filter(
+      l => l.login.toString().includes(term) || l.name.toLowerCase().includes(term)
+    );
+  }
+
+  @HostListener('window:resize')
+  onResize() {
+    this.gridApi?.sizeColumnsToFit();
+  }
+
+  exportCsv() {
+    this.gridApi.exportDataAsCsv({ fileName: 'client-master.csv' });
+  }
+
+  private formatNumber(value: number | null | undefined): string {
+    return value != null ? Number(value).toFixed(2) : '';
+  }
+}
+
+@Component({
+  selector: 'app-client-master-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatSelectModule
+  ],
+  template: `
+    <h2 mat-dialog-title>{{ data.id ? 'Edit' : 'Add' }} Client</h2>
+    <div mat-dialog-content>
+      <mat-form-field appearance="outline" class="w-100">
+        <mat-label>Login</mat-label>
+        <mat-select [(ngModel)]="data.login" disabled>
+          <mat-option *ngFor="let l of logins" [value]="l.login">
+            {{ l.login }} - {{ l.name }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <div class="triple-row">
+        <mat-form-field appearance="outline">
+          <mat-label>Manager</mat-label>
+          <mat-select [(ngModel)]="data.managerId" required>
+            <mat-option *ngFor="let m of managers" [value]="m.id">
+              {{ m.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>Broker</mat-label>
+          <mat-select [(ngModel)]="data.brokerId">
+            <mat-option *ngFor="let b of brokers" [value]="b.id">
+              {{ b.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>Exchange</mat-label>
+          <mat-select [(ngModel)]="data.exIds" multiple>
+            <mat-option *ngFor="let e of exchanges" [value]="e.id">
+              {{ e.id }} - {{ e.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+      <div class="triple-row">
+        <mat-form-field appearance="outline" class="right-align">
+          <mat-label>Brok Share</mat-label>
+          <input
+            matInput
+            type="number"
+            step="0.01"
+            [(ngModel)]="data.brokShare"
+            (blur)="formatDecimal('brokShare')"
+          />
+        </mat-form-field>
+        <mat-form-field appearance="outline" class="right-align">
+          <mat-label>Manager Share</mat-label>
+          <input
+            matInput
+            type="number"
+            step="0.01"
+            [(ngModel)]="data.managerShare"
+            (blur)="formatDecimal('managerShare')"
+          />
+        </mat-form-field>
+        <mat-form-field appearance="outline" class="right-align">
+          <mat-label>Commission</mat-label>
+          <input
+            matInput
+            type="number"
+            step="0.01"
+            [(ngModel)]="data.commission"
+            (blur)="formatDecimal('commission')"
+          />
+        </mat-form-field>
+      </div>
+      <mat-form-field appearance="outline" class="w-100">
+        <mat-label>Currency</mat-label>
+        <mat-select [(ngModel)]="data.currencyId" required>
+          <mat-option *ngFor="let c of currencies" [value]="c.id">
+            {{ c.id }} - {{ c.name }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="w-100">
+        <mat-label>Reverse Standing</mat-label>
+        <input matInput [(ngModel)]="data.reverseStanding" />
+      </mat-form-field>
+    </div>
+    <div mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Cancel</button>
+      <button
+        mat-flat-button
+        color="primary"
+        [mat-dialog-close]="data"
+        [disabled]="!data.managerId || !data.currencyId"
+      >
+        Save
+      </button>
+    </div>
+  `,
+  styles: [
+    `
+      .triple-row {
+        display: flex;
+        gap: 1rem;
+      }
+      .triple-row mat-form-field {
+        flex: 1;
+      }
+      .w-100 {
+        width: 100%;
+      }
+      .right-align input {
+        text-align: right;
+      }
+    `
+  ]
+})
+export class ClientMasterDialogComponent implements OnInit {
+  managers: MasterItem[] = [];
+  brokers: MasterItem[] = [];
+  exchanges: MasterItem[] = [];
+  currencies: MasterItem[] = [];
+  logins: LoginOption[] = [];
+
+  constructor(
+    private svc: MasterService,
+    @Inject(MAT_DIALOG_DATA) public data: ClientMasterRequest
+  ) {}
+
+  ngOnInit(): void {
+    this.svc.getLogins().subscribe(res => (this.logins = res));
+    this.svc.getManagers().subscribe(res => (this.managers = res));
+    this.svc.getBrokers().subscribe(res => (this.brokers = res));
+    this.svc.getExchanges().subscribe(res => (this.exchanges = res));
+    this.svc.getCurrencies().subscribe(res => (this.currencies = res));
+  }
+
+  formatDecimal(field: 'brokShare' | 'managerShare' | 'commission') {
+    const value = this.data[field];
+    this.data[field] = value != null ? +Number(value).toFixed(2) : 0;
+  }
+}

--- a/src/app/pages/deal-history/deal-history.component.html
+++ b/src/app/pages/deal-history/deal-history.component.html
@@ -1,0 +1,67 @@
+<mat-toolbar class="toolbar">
+  <div class="left">
+    <mat-form-field appearance="outline">
+      <mat-label>From</mat-label>
+      <input matInput [matDatepicker]="fromPicker" [(ngModel)]="fromDate" />
+      <mat-datepicker-toggle matSuffix [for]="fromPicker"></mat-datepicker-toggle>
+      <mat-datepicker #fromPicker></mat-datepicker>
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>To</mat-label>
+      <input matInput [matDatepicker]="toPicker" [(ngModel)]="toDate" />
+      <mat-datepicker-toggle matSuffix [for]="toPicker"></mat-datepicker-toggle>
+      <mat-datepicker #toPicker></mat-datepicker>
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Login</mat-label>
+      <mat-select
+        [(ngModel)]="login"
+        (openedChange)="onLoginDropdownOpen($event)"
+      >
+        <mat-option class="search-option" disabled>
+          <mat-form-field
+            appearance="outline"
+            class="login-search-field"
+            (click)="$event.stopPropagation()"
+          >
+            <mat-icon matPrefix>search</mat-icon>
+            <input
+              matInput
+              #loginSearch
+              placeholder="Search logins"
+              autocomplete="off"
+              [ngModel]="loginFilter"
+              (ngModelChange)="filterLogins($event)"
+              (click)="$event.stopPropagation()"
+              (keydown)="$event.stopPropagation()"
+              (keyup)="$event.stopPropagation()"
+            />
+          </mat-form-field>
+        </mat-option>
+        <mat-option [value]="null">-- Clear Selection --</mat-option>
+        <mat-option *ngFor="let l of filteredLogins" [value]="l.login">
+          {{ l.login }} - {{ l.name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <button mat-flat-button color="primary" (click)="show()">Show</button>
+  </div>
+  <div class="right">
+    <span>Rows: {{ rowCount }}</span>
+    <mat-form-field appearance="outline">
+      <mat-label>Search</mat-label>
+      <input matInput (input)="onFilterTextBoxChanged($event)" />
+    </mat-form-field>
+    <button mat-icon-button title="Export CSV" (click)="exportCsv()">
+      <mat-icon>table_view</mat-icon>
+    </button>
+  </div>
+</mat-toolbar>
+<div class="grid-wrapper">
+  <ag-grid-angular
+    class="ag-theme-alpine full-grid"
+    [gridOptions]="gridOptions"
+    (gridReady)="onGridReady($event)"
+  ></ag-grid-angular>
+</div>
+

--- a/src/app/pages/deal-history/deal-history.component.scss
+++ b/src/app/pages/deal-history/deal-history.component.scss
@@ -1,0 +1,55 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+
+  .left,
+  .right {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    mat-form-field {
+      width: 150px;
+    }
+
+    button.mat-icon-button {
+      background-color: #000;
+      color: #fff;
+    }
+  }
+
+  .right {
+    margin-left: auto;
+  }
+}
+
+.grid-wrapper {
+  flex: 1 1 auto;
+}
+
+:host ::ng-deep .full-grid {
+  width: 100%;
+  height: 100%;
+}
+
+:host ::ng-deep .search-option {
+  padding: 4px 8px;
+  cursor: default;
+}
+
+:host ::ng-deep .search-option.mat-mdc-option.mdc-list-item--disabled {
+  color: inherit;
+}
+
+:host ::ng-deep .login-search-field {
+  width: 100%;
+}
+

--- a/src/app/pages/deal-history/deal-history.component.ts
+++ b/src/app/pages/deal-history/deal-history.component.ts
@@ -1,0 +1,157 @@
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { AgGridModule } from 'ag-grid-angular';
+import {
+  GridApi,
+  GridOptions,
+  GridReadyEvent,
+  ColDef,
+  ModuleRegistry,
+  AllCommunityModule,
+} from 'ag-grid-community';
+import { DealsService, DealHistoryRow } from '@services/deals.service';
+import { MasterService, LoginOption } from '@services/master.service';
+import { format } from 'date-fns';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+@Component({
+  selector: 'app-deal-history',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    MatToolbarModule,
+    AgGridModule,
+  ],
+  templateUrl: './deal-history.component.html',
+  styleUrls: ['./deal-history.component.scss'],
+})
+export class DealHistoryComponent implements OnInit {
+  fromDate = new Date();
+  toDate = new Date();
+  login: number | null = null;
+  logins: LoginOption[] = [];
+  filteredLogins: LoginOption[] = [];
+  loginFilter = '';
+  @ViewChild('loginSearch') loginSearch!: ElementRef<HTMLInputElement>;
+  rowCount = 0;
+
+  gridOptions: GridOptions<DealHistoryRow> = {
+    theme: 'legacy',
+    rowHeight: 25,
+    defaultColDef: {
+      resizable: true,
+      sortable: true,
+      filter: true,
+      minWidth: 100,
+    },
+    columnDefs: [
+      { field: 'login', headerName: 'Login' },
+      {
+        field: 'time',
+        headerName: 'Time',
+        valueFormatter: p => (p.value ? format(new Date(p.value), 'dd/MM/yyyy HH:mm:ss') : '')
+      },
+      { field: 'deal', headerName: 'Deal', type: 'numericColumn', cellClass: 'ag-right-aligned-cell' },
+      { field: 'symbol', headerName: 'Symbol' },
+      { field: 'contype', headerName: 'Con Type' },
+      { field: 'qty', headerName: 'Qty', type: 'numericColumn', cellClass: 'ag-right-aligned-cell', valueFormatter: p => this.formatNumber(p.value) },
+      { field: 'price', headerName: 'Price', type: 'numericColumn', cellClass: 'ag-right-aligned-cell', valueFormatter: p => this.formatNumber(p.value) },
+      { field: 'profit', headerName: 'Profit', type: 'numericColumn', cellClass: 'ag-right-aligned-cell', valueFormatter: p => this.formatNumber(p.value) },
+      { field: 'commission', headerName: 'Commission', type: 'numericColumn', cellClass: 'ag-right-aligned-cell', valueFormatter: p => this.formatNumber(p.value) },
+      { field: 'comment', headerName: 'Comment', minWidth: 150 },
+    ],
+    rowData: [],
+    pagination: true,
+    paginationPageSize: 100,
+    paginationPageSizeSelector: [50, 100, 200],
+  };
+
+  private gridApi!: GridApi<DealHistoryRow>;
+
+  constructor(private deals: DealsService, private master: MasterService) {}
+
+  ngOnInit(): void {
+    this.master.getLogins().subscribe(res => {
+      this.logins = res;
+      this.filteredLogins = res;
+    });
+  }
+
+  onGridReady(event: GridReadyEvent<DealHistoryRow>) {
+    this.gridApi = event.api;
+  }
+
+  show() {
+    const from = format(this.fromDate, 'yyyy/MM/dd');
+    const to = format(this.toDate, 'yyyy/MM/dd');
+    this.gridApi.setGridOption('loading', true);
+    this.deals.getDealHistory(from, to, this.login ?? undefined).subscribe({
+      next: res => {
+        this.rowCount = res.rowCount;
+        this.gridApi.setGridOption('rowData', res.rows);
+        this.gridApi.sizeColumnsToFit();
+      },
+      error: () => {
+        this.gridApi.setGridOption('loading', false);
+      },
+      complete: () => {
+        this.gridApi.setGridOption('loading', false);
+      },
+    });
+  }
+
+  onFilterTextBoxChanged(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.gridApi.setGridOption('quickFilterText', value);
+  }
+
+  onLoginDropdownOpen(open: boolean) {
+    if (open) {
+      this.loginFilter = '';
+      this.filteredLogins = this.logins.slice();
+      setTimeout(() => this.loginSearch?.nativeElement.focus());
+    }
+  }
+
+  filterLogins(value: string) {
+    this.loginFilter = value;
+    const term = value.toLowerCase();
+    this.filteredLogins = this.logins.filter(
+      l =>
+        l.login.toString().includes(term) || l.name.toLowerCase().includes(term)
+    );
+  }
+
+  exportCsv() {
+    this.gridApi.exportDataAsCsv({ fileName: 'DealHistory' });
+  }
+
+  formatNumber(val: any): string {
+    const num = Number(val);
+    return isNaN(num)
+      ? ''
+      : num.toLocaleString('en-IN', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        });
+  }
+}
+

--- a/src/app/pages/deals-live/deals-live.component.ts
+++ b/src/app/pages/deals-live/deals-live.component.ts
@@ -83,7 +83,7 @@ export class DealsLiveComponent implements OnDestroy {
       minWidth: 88
     },
     rowData: [],
-    rowHeight: 26,
+    rowHeight: 34,
     rowBuffer: 0,
     rowSelection: 'single',
     animateRows: true,

--- a/src/app/pages/jobbing-deals/jobbing-deals.component.ts
+++ b/src/app/pages/jobbing-deals/jobbing-deals.component.ts
@@ -78,7 +78,7 @@ export class JobbingDealsComponent implements OnDestroy {
     },
     rowData: [],
     // Align row height with deals-live grid
-    rowHeight: 26,
+    rowHeight: 34,
     rowSelection: 'single',
     animateRows: true,
     getRowId: p => String(p.data.buyDeal) + '-' + String(p.data.sellDeal),

--- a/src/app/pages/live-orders/live-orders.component.ts
+++ b/src/app/pages/live-orders/live-orders.component.ts
@@ -77,7 +77,7 @@ export class LiveOrdersComponent implements OnDestroy {
       },
     },
     // Match row height with the deals-live grid for visual consistency
-    rowHeight: 26,
+    rowHeight: 34,
     rowSelection: 'single',
     animateRows: true,
     getRowId: p => String(p.data.order),

--- a/src/app/pages/live-summary/live-summary.component.html
+++ b/src/app/pages/live-summary/live-summary.component.html
@@ -1,0 +1,43 @@
+<mat-toolbar class="toolbar">
+  <div class="left">
+    <mat-form-field appearance="outline">
+      <mat-label>From</mat-label>
+      <input matInput [matDatepicker]="fromPicker" [(ngModel)]="fromDate" />
+      <mat-datepicker-toggle matSuffix [for]="fromPicker"></mat-datepicker-toggle>
+      <mat-datepicker #fromPicker></mat-datepicker>
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>To</mat-label>
+      <input matInput [matDatepicker]="toPicker" [(ngModel)]="toDate" />
+      <mat-datepicker-toggle matSuffix [for]="toPicker"></mat-datepicker-toggle>
+      <mat-datepicker #toPicker></mat-datepicker>
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Manager</mat-label>
+      <mat-select [(ngModel)]="managerId">
+        <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.name }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-radio-group [(ngModel)]="groupMode" class="mode-group">
+      <mat-radio-button value="symbol">Symbol wise</mat-radio-button>
+      <mat-radio-button value="login">Login wise</mat-radio-button>
+    </mat-radio-group>
+    <button mat-flat-button color="primary" (click)="show()">Show</button>
+  </div>
+  <div class="right">
+    <mat-form-field appearance="outline">
+      <mat-label>Search</mat-label>
+      <input matInput (input)="onFilterTextBoxChanged($event)" />
+    </mat-form-field>
+    <button mat-icon-button title="Export CSV" (click)="exportCsv()">
+      <mat-icon>table_view</mat-icon>
+    </button>
+  </div>
+</mat-toolbar>
+<div class="grid-wrapper">
+  <ag-grid-angular
+    class="ag-theme-alpine full-grid"
+    [gridOptions]="gridOptions"
+    (gridReady)="onGridReady($event)"
+  ></ag-grid-angular>
+</div>

--- a/src/app/pages/live-summary/live-summary.component.scss
+++ b/src/app/pages/live-summary/live-summary.component.scss
@@ -1,0 +1,58 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+
+  mat-form-field {
+    width: 150px;
+  }
+
+  .mode-group {
+    display: flex;
+    flex-direction: row;
+    margin: 0 0.5rem;
+  }
+
+  .left {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .right {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: auto;
+  }
+
+  button.mat-icon-button {
+    background-color: #000;
+    color: #fff;
+  }
+}
+
+.grid-wrapper {
+  flex: 1 1 auto;
+}
+
+:host ::ng-deep .full-grid {
+  width: 100%;
+  height: 100%;
+}
+
+:host ::ng-deep .positive {
+  color: #008000;
+}
+
+:host ::ng-deep .negative {
+  color: #ff0000;
+}

--- a/src/app/pages/live-summary/live-summary.component.ts
+++ b/src/app/pages/live-summary/live-summary.component.ts
@@ -1,0 +1,225 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatSelectModule } from '@angular/material/select';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { AgGridModule } from 'ag-grid-angular';
+import {
+  GridApi,
+  GridOptions,
+  GridReadyEvent,
+  ColDef,
+  ModuleRegistry,
+  AllCommunityModule,
+} from 'ag-grid-community';
+import { DealsService, LiveSummaryRow } from '@services/deals.service';
+import { MasterService, MasterItem } from '@services/master.service';
+import { format } from 'date-fns';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+@Component({
+  selector: 'app-live-summary',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatSelectModule,
+    MatRadioModule,
+    MatButtonModule,
+    MatIconModule,
+    MatToolbarModule,
+    AgGridModule,
+  ],
+  templateUrl: './live-summary.component.html',
+  styleUrls: ['./live-summary.component.scss'],
+})
+export class LiveSummaryComponent implements OnInit {
+  fromDate = new Date();
+  toDate = new Date();
+  managerId: number | null = null;
+  groupMode: 'symbol' | 'login' = 'symbol';
+  managers: MasterItem[] = [];
+
+  gridOptions: GridOptions<LiveSummaryRow> = {
+    theme: 'legacy',
+    rowHeight: 25,
+    defaultColDef: {
+      resizable: true,
+      sortable: true,
+      filter: true,
+      minWidth: 100,
+    },
+    columnDefs: [],
+    rowData: [],
+    pagination: true,
+    paginationPageSize: 100,
+    paginationPageSizeSelector: [50, 100, 200],
+  };
+
+  private gridApi!: GridApi<LiveSummaryRow>;
+
+  symbolColumnDefs: ColDef[] = [
+    { field: 'symbol', headerName: 'Symbol' },
+    { field: 'openQty', headerName: 'Open Qty', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'openRate', headerName: 'Open Rate', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: 'ag-right-aligned-cell' },
+    { field: 'openAmt', headerName: 'Open Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'buyQty', headerName: 'Buy Qty', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'buyAmt', headerName: 'Buy Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'sellQty', headerName: 'Sell Qty', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'sellAmt', headerName: 'Sell Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'commission', headerName: 'Commission', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: 'ag-right-aligned-cell' },
+    { field: 'closeQty', headerName: 'Close Qty', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'closeRate', headerName: 'Close Rate', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: 'ag-right-aligned-cell' },
+    { field: 'closeAmt', headerName: 'Close Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'grossMTM', headerName: 'Gross MTM', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'netAmt', headerName: 'Net Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+  ];
+
+  loginColumnDefs: ColDef[] = [
+    { field: 'login', headerName: 'Login' },
+    { field: 'symbol', headerName: 'Symbol' },
+    { field: 'openQty', headerName: 'Open Qty', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'openRate', headerName: 'Open Rate', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: 'ag-right-aligned-cell' },
+    { field: 'openAmt', headerName: 'Open Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'buyQty', headerName: 'Buy Qty', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'buyAmt', headerName: 'Buy Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'sellQty', headerName: 'Sell Qty', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'sellAmt', headerName: 'Sell Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'commission', headerName: 'Commission', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: 'ag-right-aligned-cell' },
+    { field: 'closeQty', headerName: 'Close Qty', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'closeRate', headerName: 'Close Rate', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: 'ag-right-aligned-cell' },
+    { field: 'closeAmt', headerName: 'Close Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'grossMTM', headerName: 'Gross MTM', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+    { field: 'netAmt', headerName: 'Net Amt', type: 'numericColumn', valueFormatter: p => this.formatNumber(p.value), cellClass: p => this.numericCellClass(p) },
+  ];
+
+  constructor(private deals: DealsService, private master: MasterService) {}
+
+  ngOnInit(): void {
+    this.master.getManagers().subscribe(res => (this.managers = res));
+    this.gridOptions.columnDefs = this.symbolColumnDefs;
+  }
+
+  onGridReady(event: GridReadyEvent<LiveSummaryRow>) {
+    this.gridApi = event.api;
+  }
+
+  show() {
+    const from = format(this.fromDate, 'yyyy-MM-dd');
+    const to = format(this.toDate, 'yyyy-MM-dd');
+    this.gridApi.setGridOption('loading', true);
+    this.deals
+      .getLiveSummary(from, to, this.managerId ?? undefined)
+      .subscribe({
+        next: res => {
+          let rows = res.rows.map(r => ({
+            ...r,
+            openQty: Number(r.openQty),
+            openRate: Number(r.openRate),
+            openAmt: Number(r.openAmt),
+            buyQty: Number(r.buyQty),
+            buyAmt: Number(r.buyAmt),
+            sellQty: Number(r.sellQty),
+            sellAmt: Number(r.sellAmt),
+            commission: Number(r.commission),
+            closeQty: Number(r.closeQty),
+            closeRate: Number(r.closeRate),
+            closeAmt: Number(r.closeAmt),
+            grossMTM: Number(r.grossMTM),
+            netAmt: Number(r.netAmt),
+          }));
+          if (this.groupMode === 'symbol') {
+            rows = this.groupBySymbol(rows);
+            this.gridApi.setGridOption('columnDefs', this.symbolColumnDefs);
+          } else {
+            this.gridApi.setGridOption('columnDefs', this.loginColumnDefs);
+          }
+          this.gridApi.setGridOption('rowData', rows);
+          this.gridApi.sizeColumnsToFit();
+        },
+        error: () => {
+          this.gridApi.setGridOption('loading', false);
+        },
+        complete: () => {
+          this.gridApi.setGridOption('loading', false);
+        },
+      });
+  }
+
+  onFilterTextBoxChanged(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.gridApi.setGridOption('quickFilterText', value);
+  }
+
+  exportCsv() {
+    this.gridApi.exportDataAsCsv({ fileName: 'LiveSummary' });
+  }
+
+  private groupBySymbol(rows: LiveSummaryRow[]): LiveSummaryRow[] {
+    const groups: Record<string, LiveSummaryRow[]> = {};
+    rows.forEach(r => {
+      const key = r.symbol;
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(r);
+    });
+    const result: LiveSummaryRow[] = [];
+    for (const [symbol, list] of Object.entries(groups)) {
+      const agg: LiveSummaryRow = {
+        symbol,
+        openQty: 0,
+        openRate: 0,
+        openAmt: 0,
+        buyQty: 0,
+        buyAmt: 0,
+        sellQty: 0,
+        sellAmt: 0,
+        commission: 0,
+        closeQty: 0,
+        closeRate: 0,
+        closeAmt: 0,
+        grossMTM: 0,
+        netAmt: 0,
+      };
+      list.forEach(r => {
+        agg.openQty += Number(r.openQty);
+        agg.openAmt += Number(r.openAmt);
+        agg.buyQty += Number(r.buyQty);
+        agg.buyAmt += Number(r.buyAmt);
+        agg.sellQty += Number(r.sellQty);
+        agg.sellAmt += Number(r.sellAmt);
+        agg.commission += Number(r.commission);
+        agg.closeQty += Number(r.closeQty);
+        agg.closeAmt += Number(r.closeAmt);
+        agg.grossMTM += Number(r.grossMTM);
+        agg.netAmt += Number(r.netAmt);
+      });
+      agg.openRate = agg.openQty ? agg.openAmt / agg.openQty : 0;
+      agg.closeRate = agg.closeQty ? agg.closeAmt / agg.closeQty : 0;
+      result.push(agg);
+    }
+    return result;
+  }
+
+  formatNumber(value: any): string {
+    const num = Number(value);
+    return isNaN(num) ? '0.00' : num.toFixed(2);
+  }
+
+  numericCellClass(params: any): string[] {
+    const val = Number(params.value);
+    return ['ag-right-aligned-cell', val < 0 ? 'negative' : val > 0 ? 'positive' : ''];
+  }
+}
+

--- a/src/app/pages/pages.routes.ts
+++ b/src/app/pages/pages.routes.ts
@@ -8,7 +8,8 @@ export const routes: Routes = [
     children: [
       {
         path: '',
-        loadComponent: () => import('./dashboard/dashboard.component').then(c => c.DashboardComponent),
+        loadComponent: () =>
+          import('./dashboard/dashboard.component').then(c => c.DashboardComponent),
         data: { breadcrumb: 'Dashboard' }
       },
       {
@@ -67,6 +68,16 @@ export const routes: Routes = [
         data: { breadcrumb: 'Jobbing Deals' }
       },
       {
+        path: 'standing',
+        loadComponent: () => import('./standing/standing.component').then(c => c.StandingComponent),
+        data: { breadcrumb: 'Standing' }
+      },
+      {
+        path: 'live-summary',
+        loadComponent: () => import('./live-summary/live-summary.component').then(c => c.LiveSummaryComponent),
+        data: { breadcrumb: 'Live Summary' }
+      },
+      {
         path: 'manager-master',
         loadComponent: () => import('./manager-master/manager-master.component').then(c => c.ManagerMasterComponent),
         data: { breadcrumb: 'Manager Master' }
@@ -75,6 +86,18 @@ export const routes: Routes = [
         path: 'broker-master',
         loadComponent: () => import('./broker-master/broker-master.component').then(c => c.BrokerMasterComponent),
         data: { breadcrumb: 'Broker Master' }
+      },
+
+      {
+        path: 'client-master',
+        loadComponent: () => import('./client-master/client-master.component').then(c => c.ClientMasterComponent),
+        data: { breadcrumb: 'Client Master' }
+      },
+
+      {
+        path: 'deal-history',
+        loadComponent: () => import('./deal-history/deal-history.component').then(c => c.DealHistoryComponent),
+        data: { breadcrumb: 'Deal History' }
       },
 
 

--- a/src/app/pages/standing/standing.component.html
+++ b/src/app/pages/standing/standing.component.html
@@ -1,0 +1,54 @@
+<div class="toolbar">
+  <mat-form-field appearance="outline">
+    <mat-label>As on Date</mat-label>
+    <input matInput [matDatepicker]="picker" [(ngModel)]="selectedDate" />
+    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker #picker></mat-datepicker>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Login</mat-label>
+    <mat-select [(ngModel)]="selectedLogin">
+      <mat-option [value]="null">All</mat-option>
+      <mat-option *ngFor="let l of logins" [value]="l.login">
+        {{ l.login }} - {{ l.name }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Symbol</mat-label>
+    <mat-select [(ngModel)]="selectedSymbol">
+      <mat-option [value]="null">All</mat-option>
+      <mat-option *ngFor="let s of symbols" [value]="s.name">
+        {{ s.name }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-radio-group [(ngModel)]="groupBy" (change)="onGroupChange()" class="group-by">
+    <mat-radio-button value="login">Group By Login</mat-radio-button>
+    <mat-radio-button value="symbol">Group By Symbol</mat-radio-button>
+  </mat-radio-group>
+
+  <button mat-raised-button color="primary" (click)="onShow()">Show</button>
+
+  <span class="spacer"></span>
+
+  <mat-form-field appearance="outline" class="filter-field">
+    <mat-label>Search</mat-label>
+    <input matInput type="text" (input)="onFilterTextBoxChanged($event)" />
+  </mat-form-field>
+  <button mat-icon-button (click)="exportCsv()" matTooltip="Export CSV">
+    <mat-icon>download</mat-icon>
+  </button>
+  <button mat-icon-button (click)="exportPdf()" matTooltip="Export PDF">
+    <mat-icon>picture_as_pdf</mat-icon>
+  </button>
+</div>
+
+<ag-grid-angular
+  class="ag-theme-alpine grid-flex"
+  [gridOptions]="gridOptions"
+  (gridReady)="onGridReady($event)"
+></ag-grid-angular>

--- a/src/app/pages/standing/standing.component.scss
+++ b/src/app/pages/standing/standing.component.scss
@@ -1,0 +1,61 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+
+  mat-form-field {
+    width: 200px;
+  }
+
+  .group-by {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    margin-left: 1rem;
+  }
+
+  .spacer {
+    flex: 1 1 auto;
+  }
+
+  .filter-field {
+    width: 250px;
+  }
+}
+
+:host .grid-flex {
+  width: 100%;
+}
+
+:host ::ng-deep .ag-theme-alpine {
+  width: 100%;
+  height: auto;
+}
+
+:host ::ng-deep .group-header-row {
+  background-color: #d0ebff;
+  font-weight: bold;
+}
+
+:host ::ng-deep .group-total-row {
+  background-color: #fffbe6;
+  font-weight: bold;
+  border-top: 2px solid #ccc;
+}
+
+:host ::ng-deep .buy-cell {
+  color: #1976d2;
+}
+
+:host ::ng-deep .sell-cell {
+  color: #d32f2f;
+}
+

--- a/src/app/pages/standing/standing.component.ts
+++ b/src/app/pages/standing/standing.component.ts
@@ -1,0 +1,250 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { AgGridModule } from 'ag-grid-angular';
+import {
+  GridApi,
+  GridOptions,
+  ColDef,
+  ModuleRegistry,
+  AllCommunityModule,
+} from 'ag-grid-community';
+import { DealsService, StandingRow } from '@services/deals.service';
+import { MasterService, MasterItem, LoginOption } from '@services/master.service';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+
+interface StandingGridRow extends StandingRow {
+  isGroupHeader?: boolean;
+  isGroupTotal?: boolean;
+  netQty?: number;
+}
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+@Component({
+  selector: 'app-standing',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatRadioModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+    AgGridModule,
+  ],
+  templateUrl: './standing.component.html',
+  styleUrls: ['./standing.component.scss'],
+})
+export class StandingComponent implements OnInit {
+  selectedDate: Date = new Date();
+  logins: LoginOption[] = [];
+  symbols: MasterItem[] = [];
+  selectedLogin: number | null = null;
+  selectedSymbol: string | null = null;
+  groupBy: 'login' | 'symbol' = 'login';
+  private rows: StandingGridRow[] = [];
+
+  groupColSpan(params: any): number {
+    return params.data?.isGroupHeader ? this.columnDefs.length : 1;
+  }
+
+  loginColumnDefs: ColDef<StandingGridRow>[] = [
+    { field: 'symbol', headerName: 'Symbol', colSpan: p => this.groupColSpan(p) },
+    {
+      field: 'buyQty',
+      headerName: 'Buy Qty',
+      type: 'numericColumn',
+      valueFormatter: this.formatQty,
+      cellClass: ['buy-cell', 'ag-right-aligned-cell'],
+    },
+    {
+      field: 'sellQty',
+      headerName: 'Sell Qty',
+      type: 'numericColumn',
+      valueFormatter: this.formatQty,
+      cellClass: ['sell-cell', 'ag-right-aligned-cell'],
+    },
+    {
+      field: 'netQty',
+      headerName: 'Net Qty',
+      type: 'numericColumn',
+      valueFormatter: this.formatQty,
+      cellClass: ['ag-right-aligned-cell'],
+    },
+  ];
+
+  symbolColumnDefs: ColDef<StandingGridRow>[] = [
+    { field: 'login', headerName: 'Login', colSpan: p => this.groupColSpan(p) },
+    {
+      field: 'buyQty',
+      headerName: 'Buy Qty',
+      type: 'numericColumn',
+      valueFormatter: this.formatQty,
+      cellClass: ['buy-cell', 'ag-right-aligned-cell'],
+    },
+    {
+      field: 'sellQty',
+      headerName: 'Sell Qty',
+      type: 'numericColumn',
+      valueFormatter: this.formatQty,
+      cellClass: ['sell-cell', 'ag-right-aligned-cell'],
+    },
+  ];
+
+  columnDefs: ColDef<StandingGridRow>[] = [...this.loginColumnDefs];
+
+  gridOptions: GridOptions<StandingGridRow> = {
+    theme: 'legacy',
+    // Increase row height by ~5% for better readability
+    rowHeight: 24,
+    columnDefs: this.columnDefs,
+    defaultColDef: {
+      resizable: true,
+      sortable: true,
+      filter: true,
+      minWidth: 100,
+      flex: 1,
+    },
+    rowData: [],
+    pagination: true,
+    paginationPageSize: 100,
+    paginationPageSizeSelector: [100],
+    getRowClass: params => this.getRowClass(params),
+    domLayout: 'autoHeight',
+  };
+
+  private gridApi!: GridApi<StandingGridRow>;
+
+  constructor(private deals: DealsService, private master: MasterService) {}
+
+  ngOnInit(): void {
+    this.master.getLogins().subscribe(res => (this.logins = res));
+    this.master.getSymbols().subscribe(res => (this.symbols = res));
+  }
+
+  onGridReady(params: any) {
+    this.gridApi = params.api;
+    this.updateColumnDefs();
+    this.applyGrouping();
+  }
+
+  onShow() {
+    const dateStr = this.selectedDate.toISOString().split('T')[0].replace(/-/g, '/');
+    this.deals
+      .getStanding(dateStr, this.selectedLogin, this.selectedSymbol)
+      .subscribe(res => {
+        this.rows = res.rows.map(r => ({
+          ...r,
+          netQty: (r.buyQty || 0) - (r.sellQty || 0),
+        }));
+        this.applyGrouping();
+      });
+  }
+
+  onGroupChange() {
+    this.updateColumnDefs();
+    this.applyGrouping();
+  }
+
+  onFilterTextBoxChanged(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.gridApi.setGridOption('quickFilterText', value);
+  }
+
+  exportCsv() {
+    this.gridApi.exportDataAsCsv({ fileName: 'standing.csv' });
+  }
+
+  exportPdf() {
+    const cols = this.columnDefs.map(c => c.headerName as string);
+    const fields = this.columnDefs.map(c => c.field as string);
+    const rows: any[] = [];
+    this.gridApi.forEachNode(n => {
+      const data = n.data as any;
+      if (data.isGroupHeader || data.isGroupTotal) return;
+      rows.push(fields.map(f => data[f]));
+    });
+    const doc = new jsPDF();
+    (autoTable as any)(doc, { head: [cols], body: rows });
+    doc.save('standing.pdf');
+  }
+
+  formatQty(params: any): string {
+    if (params.value === null || params.value === undefined) {
+      return '';
+    }
+    const num = Number(params.value);
+    if (!params.data?.isGroupTotal && num === 0) {
+      return '';
+    }
+    return num.toFixed(2);
+  }
+
+  private updateColumnDefs() {
+    this.columnDefs =
+      this.groupBy === 'login' ? this.loginColumnDefs : this.symbolColumnDefs;
+    if (this.gridApi) {
+      this.gridApi.setGridOption('columnDefs', this.columnDefs);
+      setTimeout(() => this.gridApi.sizeColumnsToFit(), 0);
+    }
+  }
+
+  private applyGrouping() {
+    const grouped = this.groupByKey(this.rows, this.groupBy);
+    if (this.gridApi) {
+      this.gridApi.setGridOption('rowData', grouped);
+    } else {
+      this.gridOptions.rowData = grouped;
+    }
+  }
+
+  private groupByKey(rows: StandingGridRow[], key: 'login' | 'symbol'): any[] {
+    const groups: Record<string, StandingGridRow[]> = {};
+    rows.forEach(r => {
+      const val = String((r as any)[key] ?? '');
+      groups[val] = groups[val] || [];
+      groups[val].push(r);
+    });
+    const result: any[] = [];
+    Object.entries(groups).forEach(([val, groupRows]) => {
+      const header: any = { isGroupHeader: true };
+      const displayField = key === 'login' ? 'symbol' : 'login';
+      header[displayField] = val;
+      result.push(header);
+      groupRows.forEach(r => result.push(r));
+      const total: any = { isGroupTotal: true };
+      total.buyQty = groupRows.reduce((s, r) => s + (r.buyQty || 0), 0);
+      total.sellQty = groupRows.reduce((s, r) => s + (r.sellQty || 0), 0);
+      const diff = total.buyQty - total.sellQty;
+      total.netQty = diff;
+      total[displayField] =
+        key === 'login'
+          ? `Total: ${val}`
+          : `Total: ${val} (Diff: ${diff.toFixed(2)})`;
+      result.push(total);
+    });
+    return result;
+  }
+
+  private getRowClass(params: any): string {
+    if (params.data?.isGroupHeader) return 'group-header-row';
+    if (params.data?.isGroupTotal) return 'group-total-row';
+    return '';
+  }
+}

--- a/src/app/services/deals.service.ts
+++ b/src/app/services/deals.service.ts
@@ -53,6 +53,45 @@ export interface JobbingDealRow {
   sellTimeString: string;
 }
 
+export interface StandingRow {
+  tradeDate: string;
+  login: number;
+  symbol: string;
+  buyQty: number;
+  sellQty: number;
+}
+
+export interface LiveSummaryRow {
+  login?: number;
+  symbol: string;
+  openQty: number;
+  openRate: number;
+  openAmt: number;
+  buyQty: number;
+  buyAmt: number;
+  sellQty: number;
+  sellAmt: number;
+  commission: number;
+  closeQty: number;
+  closeRate: number;
+  closeAmt: number;
+  grossMTM: number;
+  netAmt: number;
+}
+
+export interface DealHistoryRow {
+  login: number;
+  time: string;
+  deal: number;
+  symbol: string;
+  contype: string;
+  qty: number;
+  price: number;
+  profit: number;
+  commission: number;
+  comment: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class DealsService {
   constructor(private http: HttpClient) {}
@@ -89,6 +128,54 @@ export class DealsService {
       .set('intervalMinutes', intervalMinutes);
     return this.http.get<{ rows: JobbingDealRow[]; maxTime: string | null; rowCount: number }>(
       environment.apiBaseUrl + 'api/Deals/jobbing-deals',
+      { params }
+    );
+  }
+
+  getStanding(
+    date: string,
+    login?: number | null,
+    symbol?: string | null
+  ): Observable<{ rows: StandingRow[] }> {
+    let params = new HttpParams().set('date', date);
+    if (login != null) {
+      params = params.set('login', String(login));
+    }
+    if (symbol) {
+      params = params.set('symbol', symbol);
+    }
+    return this.http.get<{ rows: StandingRow[] }>(
+      environment.apiBaseUrl + 'api/Deals/standing',
+      { params }
+    );
+  }
+
+  getLiveSummary(
+    from: string,
+    to: string,
+    managerId?: number
+  ): Observable<{ rows: LiveSummaryRow[]; rowCount: number }> {
+    let params = new HttpParams().set('from', from).set('to', to);
+    if (managerId != null) {
+      params = params.set('managerId', String(managerId));
+    }
+    return this.http.get<{ rows: LiveSummaryRow[]; rowCount: number }>(
+      environment.apiBaseUrl + 'api/Deals/live-summary',
+      { params }
+    );
+  }
+
+  getDealHistory(
+    from: string,
+    to: string,
+    login?: number
+  ): Observable<{ rows: DealHistoryRow[]; rowCount: number }> {
+    let params = new HttpParams().set('from', from).set('to', to);
+    if (login != null) {
+      params = params.set('login', String(login));
+    }
+    return this.http.get<{ rows: DealHistoryRow[]; rowCount: number }>(
+      environment.apiBaseUrl + 'api/Deals/deal-history',
       { params }
     );
   }

--- a/src/app/services/master.models.ts
+++ b/src/app/services/master.models.ts
@@ -1,0 +1,35 @@
+export interface ClientMasterRequest {
+  action: string;
+  id: number;
+  login: number;
+  managerId: number;
+  brokerId: number;
+  exIds: number[];
+  brokShare: number;
+  managerShare: number;
+  currencyId: number;
+  commission: number;
+  reverseStanding?: string;
+}
+
+export interface LoginClientInfo {
+  login: number;
+  userName: string;
+  clientId: number | null;
+  managerId: number | null;
+  managerName: string;
+  brokerId: number | null;
+  brokerName: string;
+  exId: number | null;
+  exchange: string;
+  brokShare: number | null;
+  managerShare: number | null;
+  currency: string;
+  commission: number | null;
+  createdDate: string | null;
+}
+
+export interface LoginOption {
+  login: number;
+  name: string;
+}

--- a/src/app/services/master.service.ts
+++ b/src/app/services/master.service.ts
@@ -2,6 +2,11 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+import {
+  ClientMasterRequest,
+  LoginClientInfo,
+  LoginOption,
+} from './master.models';
 
 export interface MasterItem {
   id: number;
@@ -53,5 +58,62 @@ export class MasterService {
       .set('id', id);
     return this.http.delete(environment.apiBaseUrl + 'api/Master', { params });
   }
+
+  getLogins(): Observable<LoginOption[]> {
+    return this.http.get<LoginOption[]>(
+      environment.apiBaseUrl + 'api/Master/logins'
+    );
+  }
+
+  getExchanges(): Observable<MasterItem[]> {
+    return this.http.get<MasterItem[]>(
+      environment.apiBaseUrl + 'api/Master/exchanges'
+    );
+  }
+
+  getCurrencies(): Observable<MasterItem[]> {
+    return this.http.get<MasterItem[]>(
+      environment.apiBaseUrl + 'api/Master/currencies'
+    );
+  }
+
+  getSymbols(): Observable<MasterItem[]> {
+    return this.http.get<MasterItem[]>(
+      environment.apiBaseUrl + 'api/Master/symbols'
+    );
+  }
+
+  getLoginsWithClientInfo(
+    login: number | null,
+    onlyWithClientRecord: boolean
+  ): Observable<LoginClientInfo[]> {
+    let params = new HttpParams().set(
+      'onlyWithClientRecord',
+      String(onlyWithClientRecord)
+    );
+    if (login !== null) {
+      params = params.set('login', String(login));
+    }
+    return this.http.get<LoginClientInfo[]>(
+      environment.apiBaseUrl + 'api/Master/logins-with-client-info',
+      { params }
+    );
+  }
+
+  saveClientMaster(req: ClientMasterRequest): Observable<any> {
+    return this.http.post(
+      environment.apiBaseUrl + 'api/Master/client-master',
+      req
+    );
+  }
+
+  deleteClientMaster(id: number): Observable<any> {
+    const params = new HttpParams().set('id', id);
+    return this.http.delete(
+      environment.apiBaseUrl + 'api/Master/client-master',
+      { params }
+    );
+  }
 }
 
+export { ClientMasterRequest, LoginClientInfo, LoginOption } from './master.models';


### PR DESCRIPTION
## Summary
- Remove entry and volume columns in Deal History and show timestamps in `dd/MM/yyyy HH:mm:ss`
- Format Client Master "Created Date" using the same `dd/MM/yyyy HH:mm:ss` pattern

## Testing
- `npm install >/tmp/npm_install.log 2>&1 && tail -n 20 /tmp/npm_install.log`
- `npm test >/tmp/npm_test.log 2>&1 && tail -n 20 /tmp/npm_test.log`
- `npx tsc -p tsconfig.app.json --noEmit >/tmp/tsc.log 2>&1 && tail -n 20 /tmp/tsc.log`


------
https://chatgpt.com/codex/tasks/task_e_68a6a802c11c833085f91f60c8a63c84