### PR TITLE
Add profit and commission totals to deal history grid

### DIFF
--- a/src/app/pages/deal-history/deal-history.component.ts
+++ b/src/app/pages/deal-history/deal-history.component.ts
@@ -65,7 +65,12 @@ export class DealHistoryComponent implements OnInit {
       minWidth: 100,
     },
     columnDefs: [
-      { field: 'login', headerName: 'Login' },
+      {
+        field: 'login',
+        headerName: 'Login',
+        valueFormatter: params =>
+          params.node.rowPinned ? 'Totals' : params.value ?? '',
+      },
       {
         field: 'time',
         headerName: 'Time',
@@ -191,7 +196,7 @@ export class DealHistoryComponent implements OnInit {
       price: undefined as unknown as number,
       profit: profitTotal,
       commission: commissionTotal,
-      comment: 'Totals',
+      comment: '',
       __isTotalRow: true,
     };
 

--- a/src/app/pages/deal-history/deal-history.component.ts
+++ b/src/app/pages/deal-history/deal-history.component.ts
@@ -68,8 +68,13 @@ export class DealHistoryComponent implements OnInit {
       {
         field: 'login',
         headerName: 'Login',
-        valueFormatter: params =>
-          params.node.rowPinned ? 'Totals' : params.value ?? '',
+        valueFormatter: params => {
+          if (params.node?.rowPinned) {
+            return 'Totals';
+          }
+
+          return params.value ?? '';
+        },
       },
       {
         field: 'time',


### PR DESCRIPTION
## Summary
- add a pinned totals row to the deal history grid to display profit and commission sums
- recalculate the totals whenever new data is loaded or filters change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900ce5f1ec483308470c18a05fb673b